### PR TITLE
fix: correct system theme detection after new theme migration

### DIFF
--- a/src/components/ui/ThemeInit.astro
+++ b/src/components/ui/ThemeInit.astro
@@ -18,9 +18,10 @@
   ;(function () {
     function applyThemeClass() {
       const stored = localStorage.getItem('color-scheme')
-      const isDark = stored
-        ? stored === 'dark'
-        : window.matchMedia('(prefers-color-scheme: dark)').matches
+      const isDark =
+        stored === 'dark' ||
+        (stored !== 'light' &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches)
       document.documentElement.classList.toggle('dark', isDark)
     }
 
@@ -29,7 +30,8 @@
     window
       .matchMedia('(prefers-color-scheme: dark)')
       .addEventListener('change', function () {
-        if (!localStorage.getItem('color-scheme')) {
+        const stored = localStorage.getItem('color-scheme')
+        if (!stored || stored === 'auto') {
           applyThemeClass()
         }
       })

--- a/src/components/ui/ThemeToggle.astro
+++ b/src/components/ui/ThemeToggle.astro
@@ -69,8 +69,7 @@ import CircleIcon from '~icons/ri/circle-fill'
           `circle(0px at ${x}px ${y}px)`,
           `circle(${endRadius}px at ${x}px ${y}px)`,
         ]
-        const isDark =
-          document.documentElement.getAttribute('data-theme') === 'dark'
+        const isDark = document.documentElement.classList.contains('dark')
         document.documentElement.animate(
           { clipPath: isDark ? [...clipPath].reverse() : clipPath },
           {


### PR DESCRIPTION
Three bugs introduced in the new theme structure:

- applyThemeClass() treated stored 'auto' as falsy-truthy and evaluated
  'auto' === 'dark' → always false, forcing light mode regardless of OS
- The prefers-color-scheme change listener only fired when localStorage
  had no entry; storing 'auto' explicitly (as ThemeToggle does) silently
  blocked all auto-switching
- View transition animation checked data-theme attribute instead of the
  html.dark class used by the new theming system, breaking animation direction

https://claude.ai/code/session_017pGq8SWZWM29yV44tDoHMh