### PR TITLE
Improve OEmbed dark mode styling and video container appearance

### DIFF
--- a/src/components/ui/OEmbed.astro
+++ b/src/components/ui/OEmbed.astro
@@ -346,10 +346,16 @@ const { url, maxWidth = 800 } = Astro.props
 
   .video-container {
     @apply relative h-0 overflow-hidden pb-[56.25%];
+    background-color: var(--bg);
   }
 
   .video-container iframe {
     @apply absolute top-0 left-0 w-full h-full;
+  }
+
+  :global([data-theme='dark']) .oembed-content iframe {
+    color-scheme: dark;
+    background-color: var(--bg);
   }
 
   .oembed-content a {


### PR DESCRIPTION
## Summary
Enhanced the OEmbed component's styling to better support dark mode themes and improve the visual presentation of embedded video containers.

## Key Changes
- Added `background-color: var(--bg)` to `.video-container` to ensure proper background rendering
- Added dark mode specific styling for iframes within the OEmbed content:
  - Set `color-scheme: dark` to signal dark mode preference to embedded content
  - Applied `background-color: var(--bg)` for consistent dark background rendering

## Implementation Details
The changes target the `OEmbed.astro` component's style block and introduce a new CSS rule that applies specifically when `data-theme='dark'` is set globally. This ensures that embedded iframes (particularly video players) respect the dark theme preference and render with appropriate colors and backgrounds, improving the overall visual consistency in dark mode.

https://claude.ai/code/session_01SMWusxzi1VY5TeUb8h7JUM