### PR TITLE
Optimize image loading based on priority flag in Satteri processor

### DIFF
--- a/src/plugins/satteri-image-processor.mjs
+++ b/src/plugins/satteri-image-processor.mjs
@@ -21,8 +21,8 @@ export function createSatteriImageProcessorPlugin() {
           }
 
           ctx.setProperty(node, 'data-preview', 'true')
-          ctx.setProperty(node, 'loading', 'lazy')
-          ctx.setProperty(node, 'decoding', 'async')
+          ctx.setProperty(node, 'loading', shouldPrioritize ? 'eager' : 'lazy')
+          ctx.setProperty(node, 'decoding', shouldPrioritize ? 'sync' : 'async')
           ctx.setProperty(node, 'className', classes)
           if (shouldPrioritize) {
             ctx.setProperty(node, 'fetchpriority', 'high')


### PR DESCRIPTION
## Summary
Updated the Satteri image processor plugin to dynamically set image loading and decoding attributes based on whether an image should be prioritized, improving performance for critical images.

## Key Changes
- Modified `loading` attribute to use `'eager'` for prioritized images instead of always using `'lazy'`
- Modified `decoding` attribute to use `'sync'` for prioritized images instead of always using `'async'`
- These changes work in conjunction with the existing `fetchpriority: 'high'` flag for prioritized images

## Implementation Details
The plugin now respects the `shouldPrioritize` flag to optimize image loading behavior:
- **Prioritized images**: Use eager loading and synchronous decoding for faster rendering
- **Non-prioritized images**: Continue using lazy loading and asynchronous decoding for better overall page performance

This allows the plugin to handle above-the-fold and critical images more efficiently while maintaining lazy loading for below-the-fold content.

https://claude.ai/code/session_016py5xpKJtPeTbFYAPxeS1C