### PR TITLE
fix: restore theme toggle view-transition animation

### DIFF
--- a/src/components/layout/TransitionWrapper.astro
+++ b/src/components/layout/TransitionWrapper.astro
@@ -47,4 +47,25 @@ const { class: className = '' } = Astro.props
       transform: translateZ(0);
     }
   }
+
+  /* Theme toggle transition (view-transition API) */
+  .theme-transition::view-transition-old(root) {
+    animation: none;
+    mix-blend-mode: normal;
+    z-index: 1;
+  }
+
+  .theme-transition::view-transition-new(root) {
+    animation: none;
+    mix-blend-mode: normal;
+    z-index: 9999;
+  }
+
+  html[data-theme='dark'].theme-transition::view-transition-old(root) {
+    z-index: 9999;
+  }
+
+  html[data-theme='dark'].theme-transition::view-transition-new(root) {
+    z-index: 1;
+  }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -196,26 +196,3 @@ html:not([data-theme='dark']) .img-dark,
 html:not([data-theme='dark']) [img-dark] {
   @apply hidden;
 }
-
-/* Theme toggle transition (view-transition API) */
-.theme-transition::view-transition-old(root),
-.theme-transition::view-transition-new(root) {
-  animation: none;
-  mix-blend-mode: normal;
-}
-
-.theme-transition::view-transition-old(root) {
-  @apply z-1;
-}
-
-.theme-transition::view-transition-new(root) {
-  @apply z-9999;
-}
-
-html[data-theme='dark'].theme-transition::view-transition-old(root) {
-  @apply z-9999;
-}
-
-html[data-theme='dark'].theme-transition::view-transition-new(root) {
-  @apply z-1;
-}


### PR DESCRIPTION
The Astro 7 CSS bundler/minifier was silently dropping rules that
share identical declaration blocks for ::view-transition-old/new(root)
across different selectors, breaking the circular reveal animation
on theme toggle. Move the rules into TransitionWrapper's inline style
block, which bypasses the bundler.

https://claude.ai/code/session_01S2LndZSaUmisDHXpS2orra