### PR TITLE
fix: unwrap CSS cascade layers to fix iOS 27 beta blank styling

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import { createSatteriHeadingsPlugin } from './src/plugins/satteri-headings.mjs'
 import { satteriLinkCard } from './src/plugins/satteri-link-card.mjs'
 import { createSatteriCleanupPlugin } from './src/plugins/satteri-cleanup.mjs'
 import { createSatteriImageProcessorPlugin } from './src/plugins/satteri-image-processor.mjs'
+import { unwrapCssLayers } from './src/plugins/vite-unwrap-css-layers.mjs'
 import Icons from 'unplugin-icons/vite'
 
 export default defineConfig({
@@ -106,6 +107,7 @@ export default defineConfig({
         scale: 1.2,
         defaultStyle: 'display: inline-block; vertical-align: text-bottom;',
       }),
+      unwrapCssLayers(),
     ],
     build: {
       minify: 'terser',

--- a/src/plugins/vite-unwrap-css-layers.mjs
+++ b/src/plugins/vite-unwrap-css-layers.mjs
@@ -35,11 +35,16 @@ function unwrapLayers(css) {
   return out
 }
 
-// Some iOS Safari betas silently drop @layer contents without any console
-// error, leaving the page fully unstyled. Tailwind v4 always emits its
-// output inside @layer blocks in correct cascade order (properties, theme,
-// base, components, utilities), so unwrapping them in place is safe and
-// preserves the same effective rule order.
+// TEMPORARY WORKAROUND — remove once iOS Safari fixes cascade-layer support
+// or Tailwind stops relying on @layer for its output.
+//
+// Some iOS Safari betas (confirmed: iOS 27 beta) silently drop @layer
+// contents without any console error, leaving the page fully unstyled.
+// Tailwind v4 always emits its output inside @layer blocks in correct
+// cascade order (properties, theme, base, components, utilities), so
+// unwrapping them in place is safe and preserves the same effective rule
+// order. Re-test on affected iOS versions periodically and drop this plugin
+// once the regression is resolved upstream.
 export function unwrapCssLayers() {
   return {
     name: 'unwrap-css-layers',

--- a/src/plugins/vite-unwrap-css-layers.mjs
+++ b/src/plugins/vite-unwrap-css-layers.mjs
@@ -1,0 +1,55 @@
+function unwrapLayers(css) {
+  let out = ''
+  let i = 0
+  const opener = /@layer\s+[a-zA-Z-]+\s*\{/y
+
+  while (i < css.length) {
+    opener.lastIndex = i
+    const match = opener.exec(css)
+
+    if (match && match.index === i) {
+      let depth = 1
+      let j = i + match[0].length
+      while (depth > 0 && j < css.length) {
+        if (css[j] === '{') depth++
+        else if (css[j] === '}') depth--
+        j++
+      }
+      out += css.slice(i + match[0].length, j - 1)
+      i = j
+      continue
+    }
+
+    if (css.startsWith('@layer', i)) {
+      const end = css.indexOf(';', i)
+      if (end !== -1) {
+        i = end + 1
+        continue
+      }
+    }
+
+    out += css[i]
+    i++
+  }
+
+  return out
+}
+
+// Some iOS Safari betas silently drop @layer contents without any console
+// error, leaving the page fully unstyled. Tailwind v4 always emits its
+// output inside @layer blocks in correct cascade order (properties, theme,
+// base, components, utilities), so unwrapping them in place is safe and
+// preserves the same effective rule order.
+export function unwrapCssLayers() {
+  return {
+    name: 'unwrap-css-layers',
+    enforce: 'post',
+    generateBundle(_options, bundle) {
+      for (const file of Object.values(bundle)) {
+        if (file.type === 'asset' && file.fileName.endsWith('.css')) {
+          file.source = unwrapLayers(file.source.toString())
+        }
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- vinh.dev renders completely unstyled on iOS 27 beta Safari (no fonts/colors/layout), while the same build works fine on desktop and the sibling astro-chiri site is unaffected on the same beta
- Safari's on-device console shows no errors and the stylesheet loads with a 200 and correct `text/css` content-type, ruling out CSP/MIME/network issues
- The key structural difference: this site's Tailwind v4 CSS output wraps everything in `@layer` blocks (`properties`/`theme`/`base`/`components`/`utilities`), while astro-chiri has zero `@layer` usage — "rules present, no errors, nothing applies" matches a cascade-layer engine regression
- Adds a Vite build plugin that strips `@layer` wrappers from the final CSS bundle (Lightning CSS's browser `targets` option doesn't unwrap layers, so this is a custom mechanical transform), preserving rule order since Tailwind already emits layers in correct cascade order and nothing here uses `layer()`/`revert-layer`

## Test plan
- [x] `bun run build` succeeds, output CSS has zero `@layer` occurrences, braces balanced
- [x] `astro preview` — spot-checked homepage CSS output is rule-for-rule identical to before, just unwrapped
- [ ] Test the Cloudflare preview deployment for this branch on the iOS 27 beta device where the bug reproduces (the real pass/fail signal)